### PR TITLE
relax solidus_support version dependency

### DIFF
--- a/solidus_simple_shopify_import.gemspec
+++ b/solidus_simple_shopify_import.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'httparty', '>= 0.18.0'
   spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 3']
-  spec.add_dependency 'solidus_support', '~> 0.4.0'
+  spec.add_dependency 'solidus_support', '~> 0.5'
 
   spec.add_development_dependency 'solidus_dev_support'
 end


### PR DESCRIPTION
update `solidus_support` and relax version required, so minimize conflict with other gems when `solidus_support` version change